### PR TITLE
Fix divide by zero in MBSP notebook

### DIFF
--- a/notebooks/mbsp_demo.ipynb
+++ b/notebooks/mbsp_demo.ipynb
@@ -63,7 +63,7 @@
     "    r11 = b11.astype(float)\n",
     "    r12 = b12.astype(float)\n",
     "    c = np.sum(r11 * r12) / np.sum(r11 ** 2)\n",
-    "    return (c * r12 - r11) / r11\n",
+    "    return np.divide(c * r12 - r11, r11, out=np.full_like(r11, np.nan), where=r11 != 0)\n",
     "\n",
     "def process_stack(collection):\n",
     "    \"\"\"Iterate through the collection and compute MBSP for each image.\"\"\"\n",


### PR DESCRIPTION
## Summary
- prevent division by zero when computing MBSP in the demo notebook

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840b921aa10832dade5e997a7a69830